### PR TITLE
tool-audit: 2026-04 proposals

### DIFF
--- a/tool-audit/2026-04.md
+++ b/tool-audit/2026-04.md
@@ -1,0 +1,133 @@
+# Tool Audit — 2026-04
+
+Generated: 2026-04-07
+
+## Summary
+- Tools reviewed: 30
+- Retirement proposals: 2
+- Addition proposals: 5
+
+---
+
+## Retirement Proposals
+
+### @modelcontextprotocol/server-github
+- **Currently in**: install-mcp.sh
+- **Reason**: The npm package carries an explicit deprecation notice. Maintenance moved to `github/github-mcp-server`, which is now the officially GitHub-maintained MCP server with active development and a superset of features.
+- **Last release**: 2025-04-08 (v2025.4.8) — ~1 year ago, no updates since
+- **Evidence**: https://www.npmjs.com/package/@modelcontextprotocol/server-github
+- **Successor**: `github/github-mcp-server` — https://github.com/github/github-mcp-server
+- **Proposed change**: Replace lines 134–135 in install-mcp.sh:
+  ```bash
+  # Before:
+  add_mcp_tracked github \
+    -- npx -y @modelcontextprotocol/server-github
+
+  # After:
+  add_mcp_tracked github \
+    -- npx -y @github/mcp-server
+  ```
+
+### @modelcontextprotocol/server-brave-search
+- **Currently in**: install-mcp.sh
+- **Reason**: The Anthropic-side reference implementation has not been updated in ~1 year. Brave now publishes their own first-party package `@brave/brave-search-mcp-server` (currently v2.0.75), which is actively maintained, has broader search capabilities (web, image, video, news, local search), and is the recommended replacement per Brave's own documentation.
+- **Last release**: ~2025 (v0.6.2) — ~1 year ago
+- **Evidence**: https://www.npmjs.com/package/@modelcontextprotocol/server-brave-search and https://www.npmjs.com/package/@brave/brave-search-mcp-server
+- **Successor**: `@brave/brave-search-mcp-server` — https://github.com/brave/brave-search-mcp-server
+- **Proposed change**: Replace lines 142–143 in install-mcp.sh:
+  ```bash
+  # Before:
+  add_mcp_tracked brave-search \
+    -- npx -y @modelcontextprotocol/server-brave-search
+
+  # After:
+  add_mcp_tracked brave-search \
+    -- npx -y @brave/brave-search-mcp-server
+  ```
+
+---
+
+## Addition Proposals
+
+### atuin
+- **Purpose**: Replaces shell history with a SQLite database; records command context (exit code, duration, cwd, hostname); supports optional end-to-end encrypted cross-machine sync
+- **Fits focus area**: Developer productivity, agentic AI (command replay and auditing in agent loops)
+- **Stars / last release**: ~29,000 stars, last release v18.4 (2026, within last 6 months)
+- **Install**: `brew install atuin` (macOS); `bash <(curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh)` (Linux)
+- **Evidence**: https://github.com/atuinsh/atuin
+- **Proposed change**: Add to install-system.sh alongside zoxide (both are shell enhancements installed via brew/curl). Wire shell init in install-dotfiles.sh with `eval "$(atuin init zsh)"` / `eval "$(atuin init bash)"`.
+
+### delta (git-delta)
+- **Purpose**: Syntax-highlighting pager for `git diff`, `git show`, `git log`, and `blame`; side-by-side diffs with line numbers; integrates with lazygit
+- **Fits focus area**: Developer productivity
+- **Stars / last release**: ~30,000 stars, last release v0.19.2 (2026-03-28)
+- **Install**: `brew install git-delta` (macOS); `apt install git-delta` (Ubuntu 22.04+) or binary from GitHub releases
+- **Evidence**: https://github.com/dandavison/delta
+- **Proposed change**: Add to install-system.sh in the APT/brew packages section. Wire as git pager in install-dotfiles.sh by appending to `~/.gitconfig`:
+  ```
+  [core]
+      pager = delta
+  [interactive]
+      diffFilter = delta --color-only
+  ```
+
+### MCP Memory (Knowledge Graph)
+- **Purpose**: Official Anthropic MCP server that gives AI agents a persistent knowledge graph across sessions — entities, relations, and observations stored between conversations
+- **Fits focus area**: Agentic AI, MCP-based tool integration
+- **Stars / last release**: Part of modelcontextprotocol/servers repo (~83,000 combined stars), last release v2026.1.26 (2026-01-26)
+- **Install**: `claude mcp add memory --scope user -- npx -y @modelcontextprotocol/server-memory`
+- **Evidence**: https://github.com/modelcontextprotocol/servers/tree/main/src/memory
+- **Proposed change**: Add to the MCP Servers section in install-mcp.sh alongside the other `add_mcp_tracked` calls:
+  ```bash
+  # memory — persistent knowledge graph across agent sessions
+  add_mcp_tracked memory \
+    -- npx -y @modelcontextprotocol/server-memory
+  ```
+
+### mise
+- **Purpose**: Polyglot dev-tool version manager covering 950+ tools (Node, Python, Ruby, Go, Rust, Java, and more) plus per-project env vars and a task runner; a superset of fnm that also subsumes pyenv and asdf
+- **Fits focus area**: Developer productivity, agentic AI (reproducible environments for agent tasks)
+- **Stars / last release**: ~26,000 stars, last release 2026.4.1 (2026-04, calendar versioning)
+- **Install**: `brew install mise` (macOS); `curl https://mise.run | sh` (Linux)
+- **Evidence**: https://github.com/jdx/mise
+- **Proposed change**: Add to install-system.sh. Note: mise can manage Node (subsumes fnm) but add alongside fnm for now — full migration can be a separate proposal once mise adoption is confirmed. Wire shell init in install-dotfiles.sh with `eval "$(mise activate zsh)"` / `eval "$(mise activate bash)"`.
+
+### goose (by Block)
+- **Purpose**: Extensible open-source AI agent (by Block/Square); autonomously installs deps, edits files, runs tests; works with local Ollama models and any OpenAI-compatible endpoint; native first-class MCP client
+- **Fits focus area**: Agentic AI, MCP-based tool integration
+- **Stars / last release**: ~27,000 stars, last release v1.29.1 (2026-04-03)
+- **Install**: `curl -fsSL https://github.com/block/goose/releases/latest/download/install.sh | bash` (macOS + Linux); binary releases for both platforms. Apache 2.0 licensed.
+- **Evidence**: https://github.com/block/goose
+- **Proposed change**: Add to install-ai.sh in a new "Agentic CLI Tools" section after the Aider install. Unlike Aider (pair-programming mode) and Claude Code (Claude-specific), goose is model-agnostic and designed for autonomous engineering loops against local Ollama models — no cloud API key required.
+
+---
+
+## No Change — Reviewed and Healthy
+
+- ripgrep — v15.1.0, last release 2025-10-22
+- bat — v0.26.1, last release 2025-12-02
+- fzf — v0.71.0, last release 2026-04-04
+- eza — v0.23.4, last release 2025-10-03
+- zoxide — v0.9.9, last release 2026-01-31
+- jq — v1.8.1, last release 2025-07-01
+- yq — v4.52.5, last release 2026-03-25
+- fnm — v1.39.0, last release 2025-03-06
+- tmux — v3.6a, last release 2025-12-05
+- uv — v0.11.3, last release 2026-04-01
+- Ollama — v0.20.2, last release 2026-04-04
+- Aider — v0.86.2, last release 2026-02-12
+- llm CLI — v0.30, last release 2026-03-31
+- Docker + Compose — Compose v5.1.1, last release 2026-03-20
+- Open WebUI — v0.8.12, last release 2026-03-27
+- lazygit — v0.60.0, last release 2026-03-10
+- k9s — v0.50.18, last release ~2026-01
+- starship — v1.24.2, last release 2025-12-30
+- gh (GitHub CLI) — v2.88.1, last release ~2026-03
+- glab (GitLab CLI) — ~v1.58+, last release ~2026-04-01
+- Terraform — v1.14.7, last release 2026-03-11 ⚠️ BSL license since Aug 2023; OpenTofu (v1.11, CNCF) is the OSS alternative — no change proposed this cycle but worth tracking
+- Ansible — v13.5.0 (community), last release 2026-03-25
+- kubectl — v1.35.3, last release 2026-03-19
+- Helm — v4.1.3, last release ~2026-03 (Helm 4.0 was released Nov 2025 — install script targets `get-helm-3` which auto-installs v4; no script change needed)
+- Claude Code CLI — v2.1.87, last release ~2026-04
+- MCP: filesystem — v2026.1.14, last release 2026-01-14
+- MCP: playwright — v0.0.69, last release ~2026-04


### PR DESCRIPTION
# Tool Audit — 2026-04

Generated: 2026-04-07

## Summary
- Tools reviewed: 30
- Retirement proposals: 2
- Addition proposals: 5

---

## Retirement Proposals

### @modelcontextprotocol/server-github
- **Currently in**: install-mcp.sh
- **Reason**: The npm package carries an explicit deprecation notice. Maintenance moved to `github/github-mcp-server`, which is now the officially GitHub-maintained MCP server with active development and a superset of features.
- **Last release**: 2025-04-08 (v2025.4.8) — ~1 year ago, no updates since
- **Evidence**: https://www.npmjs.com/package/@modelcontextprotocol/server-github
- **Successor**: `github/github-mcp-server` — https://github.com/github/github-mcp-server
- **Proposed change**: Replace lines 134–135 in install-mcp.sh with `npx -y @github/mcp-server`

### @modelcontextprotocol/server-brave-search
- **Currently in**: install-mcp.sh
- **Reason**: The Anthropic-side reference implementation has not been updated in ~1 year. Brave now publishes their own first-party package `@brave/brave-search-mcp-server` (v2.0.75), which is actively maintained and has broader search capabilities (web, image, video, news, local search).
- **Last release**: ~2025 (v0.6.2) — ~1 year ago
- **Evidence**: https://www.npmjs.com/package/@brave/brave-search-mcp-server
- **Proposed change**: Replace lines 142–143 in install-mcp.sh with `npx -y @brave/brave-search-mcp-server`

---

## Addition Proposals

### atuin
- **Purpose**: Replaces shell history with a SQLite database; records command context (exit code, duration, cwd, hostname); optional end-to-end encrypted cross-machine sync
- **Fits focus area**: Developer productivity, agentic AI
- **Stars / last release**: ~29,000 stars, v18.4 (2026)
- **Install**: `brew install atuin` / `bash <(curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh)`
- **Evidence**: https://github.com/atuinsh/atuin
- **Proposed change**: Add to install-system.sh + wire init in install-dotfiles.sh

### delta (git-delta)
- **Purpose**: Syntax-highlighting pager for `git diff`, `git show`, `git log`, and `blame`; side-by-side diffs; integrates with lazygit
- **Fits focus area**: Developer productivity
- **Stars / last release**: ~30,000 stars, v0.19.2 (2026-03-28)
- **Install**: `brew install git-delta` / `apt install git-delta`
- **Evidence**: https://github.com/dandavison/delta
- **Proposed change**: Add to install-system.sh + wire as git pager in install-dotfiles.sh

### MCP Memory (Knowledge Graph)
- **Purpose**: Official Anthropic MCP server for persistent knowledge graph across agent sessions — entities, relations, and observations stored between conversations
- **Fits focus area**: Agentic AI, MCP-based tool integration
- **Stars / last release**: Part of modelcontextprotocol/servers (~83,000 stars), v2026.1.26 (2026-01-26)
- **Install**: `npx -y @modelcontextprotocol/server-memory`
- **Evidence**: https://github.com/modelcontextprotocol/servers/tree/main/src/memory
- **Proposed change**: Add `add_mcp_tracked memory` call to install-mcp.sh

### mise
- **Purpose**: Polyglot dev-tool version manager (950+ tools: Node, Python, Ruby, Go, Rust, Java…) + per-project env vars + task runner; superset of fnm
- **Fits focus area**: Developer productivity
- **Stars / last release**: ~26,000 stars, 2026.4.1 (2026-04)
- **Install**: `brew install mise` / `curl https://mise.run | sh`
- **Evidence**: https://github.com/jdx/mise
- **Proposed change**: Add to install-system.sh + wire shell init in install-dotfiles.sh; add alongside fnm for now

### goose (by Block)
- **Purpose**: Model-agnostic open-source AI agent (by Block/Square); autonomously edits files, runs tests, installs deps; works with local Ollama models; native MCP client
- **Fits focus area**: Agentic AI, MCP-based tool integration
- **Stars / last release**: ~27,000 stars, v1.29.1 (2026-04-03)
- **Install**: `curl -fsSL https://github.com/block/goose/releases/latest/download/install.sh | bash`
- **Evidence**: https://github.com/block/goose
- **Proposed change**: Add to install-ai.sh in a new "Agentic CLI Tools" section after Aider

---

## No Change — Reviewed and Healthy

ripgrep — v15.1.0, 2025-10-22 | bat — v0.26.1, 2025-12-02 | fzf — v0.71.0, 2026-04-04 | eza — v0.23.4, 2025-10-03 | zoxide — v0.9.9, 2026-01-31 | jq — v1.8.1, 2025-07-01 | yq — v4.52.5, 2026-03-25 | fnm — v1.39.0, 2025-03-06 | tmux — v3.6a, 2025-12-05 | uv — v0.11.3, 2026-04-01 | Ollama — v0.20.2, 2026-04-04 | Aider — v0.86.2, 2026-02-12 | llm CLI — v0.30, 2026-03-31 | Docker+Compose — v5.1.1, 2026-03-20 | Open WebUI — v0.8.12, 2026-03-27 | lazygit — v0.60.0, 2026-03-10 | k9s — v0.50.18, ~2026-01 | starship — v1.24.2, 2025-12-30 | gh — v2.88.1, ~2026-03 | glab — ~2026-04-01 | Terraform — v1.14.7, 2026-03-11 (⚠️ BSL license; OpenTofu is the OSS fork — worth tracking) | Ansible — v13.5.0, 2026-03-25 | kubectl — v1.35.3, 2026-03-19 | Helm — v4.1.3, ~2026-03 | Claude Code CLI — v2.1.87, ~2026-04 | MCP filesystem — v2026.1.14, 2026-01-14 | MCP playwright — v0.0.69, ~2026-04

https://claude.ai/code/session_0139gdGik69kyWfUxFcwzoms