### PR TITLE
Wire shared PROFILE.md into ~/.claude + reprint MOTD in tmux

### DIFF
--- a/dev-workstation-build/install-dotfiles.sh
+++ b/dev-workstation-build/install-dotfiles.sh
@@ -260,12 +260,17 @@ section "tmux"
 # Auto-start tmux for interactive standalone terminals. Skips when already inside
 # tmux, non-interactive, or in an IDE/embedded terminal (vscode/kiro/cursor/
 # Antigravity/JetBrains) whose shell integration tmux would break.
+# Reprint the login banner/MOTD inside the new tmux session — tmux switches the
+# terminal's screen buffer on attach, which wipes the SSH pre-auth banner
+# (/etc/issue.net) and MOTD. Single-quoted so $f/$SHELL expand when tmux runs it,
+# not when the RC is sourced. Inside tmux $TMUX is set, so the exec'd login shell
+# won't recurse into this block.
 TMUX_AUTOSTART='# ── Auto-start tmux (workstation) ──
 if command -v tmux &>/dev/null && [[ $- == *i* ]] && [[ -z "${TMUX:-}" ]]; then
   case "${TERM_PROGRAM:-}" in
     vscode | kiro | cursor | Cursor | Antigravity) ;;
     *)
-      [[ -z "${TERMINAL_EMULATOR:-}" ]] && exec tmux new-session
+      [[ -z "${TERMINAL_EMULATOR:-}" ]] && exec tmux new-session '\''for f in /etc/issue.net /run/motd.dynamic /etc/motd; do [ -s "$f" ] && cat "$f"; done; exec "${SHELL:-/bin/bash}" -l'\''
       ;;
   esac
 fi'

--- a/setup.sh
+++ b/setup.sh
@@ -407,7 +407,11 @@ if is_selected "_claude_skills"; then
     for skill_dir in "$CLAUDE_SKILLS_SRC"/*/; do
       skill_name="$(basename "$skill_dir")"
       target="$CLAUDE_SKILLS_DEST/$skill_name"
-      if [ -L "$target" ]; then
+      if [ -L "$target" ] && [ ! -e "$target" ]; then
+        rm "$target"
+        ln -s "$skill_dir" "$target"
+        ok "Claude skill: $skill_name (repaired dangling symlink)"
+      elif [ -L "$target" ]; then
         skip "Claude skill: $skill_name (symlink exists)"
       elif [ -e "$target" ]; then
         echo -e "${RED}[conflict]${RESET} $target exists and is not a symlink — skipping"
@@ -416,6 +420,27 @@ if is_selected "_claude_skills"; then
         ok "Claude skill: $skill_name"
       fi
     done
+  fi
+
+  # Wire the shared profile — skills read it from ~/.claude/PROFILE.md
+  PROFILE_SRC="$REPO_DIR/skills/common/PROFILE.md"
+  PROFILE_DEST="$HOME/.claude/PROFILE.md"
+
+  if $DRY_RUN; then
+    dryrun "Would symlink: $PROFILE_DEST -> $PROFILE_SRC"
+  else
+    if [ -L "$PROFILE_DEST" ] && [ ! -e "$PROFILE_DEST" ]; then
+      rm "$PROFILE_DEST"
+      ln -s "$PROFILE_SRC" "$PROFILE_DEST"
+      ok "PROFILE.md (repaired dangling symlink)"
+    elif [ -L "$PROFILE_DEST" ]; then
+      skip "PROFILE.md (symlink exists)"
+    elif [ -e "$PROFILE_DEST" ]; then
+      echo -e "${RED}[conflict]${RESET} $PROFILE_DEST exists and is not a symlink — skipping"
+    else
+      ln -s "$PROFILE_SRC" "$PROFILE_DEST"
+      ok "PROFILE.md"
+    fi
   fi
 fi
 
@@ -436,7 +461,11 @@ if is_selected "_cursor_rules"; then
     for workflow in "$CURSOR_RULES_SRC"/*.md; do
       name="$(basename "$workflow")"
       target="$CURSOR_RULES_DEST/$name"
-      if [ -L "$target" ]; then
+      if [ -L "$target" ] && [ ! -e "$target" ]; then
+        rm "$target"
+        ln -s "$workflow" "$target"
+        ok "Cursor rule: $name (repaired dangling symlink)"
+      elif [ -L "$target" ]; then
         skip "Cursor rule: $name (symlink exists)"
       else
         ln -s "$workflow" "$target"

--- a/skills/common/PROFILE.md
+++ b/skills/common/PROFILE.md
@@ -3,7 +3,7 @@
 ## Identity
 
 - **Location:** Ryde, Sydney, NSW, Australia
-- **Blog:** [andrewriley.info](https://andrewriley.info) (Hugo)
+- **Website:** [andrewriley.info](https://andrewriley.info) — portfolio and digital CV built around proof-of-work themes (lead, build, play, health); Next.js 16 + MDX on Cloudflare ([repo](https://github.com/andrewkriley/www-andrewriley-info)); migrated from Hugo
 - **Role:** Tech Lead / Architect
 
 ## Technical Focus Areas
@@ -12,6 +12,7 @@
 - **AI / LLMs** — AI tooling, Claude Code skills, MCP integrations, homeaiops project (Home Assistant + Claude)
 - **Observability / Splunk** — Splunk in the homelab for network and system monitoring; MCP-connected to Claude Code and Claude Desktop; uses natural language querying and Dashboard Studio for visualisation
 - **Cloud & Infrastructure** — GitOps practices, VLAN segmentation, UniFi networking, Meraki MX appliances, Traefik, CI/CD pipelines
+- **Security & access hygiene** — Audits his own AI tooling surface (MCP servers, tokens, filesystem, permissions) with a dedicated `/security-audit` skill; runs Gitleaks + ShellCheck in CI on his personal repos
 - **Home Automation** — Deep Home Assistant user; builds custom integrations and HACS-distributed components
 - **Community contributor** — Submits to open source projects (HACS, HA Brands repo)
 
@@ -31,11 +32,12 @@
 ### Signature traits observed across blog posts
 - **Creative storytelling**: Will use unexpected narrative formats to explain technical topics — e.g. a fantasy epic ("The Ballad of Packet the Brave") to describe network infrastructure. Not afraid to be playful or experimental with format.
 - **Honest about imperfection**: Openly calls out technical debt, ugly hacks, and "things I still need to fix" rather than pretending everything is polished.
-- **Production-grade mindset at home**: Treats personal infrastructure with the same rigour as professional systems — GitOps, approval gates, SAST, documented architecture.
+- **Production-grade mindset at home**: Treats personal infrastructure with the same rigour as professional systems — GitOps, approval gates, SAST, documented architecture, SemVer-versioned releases even for personal tooling repos.
 - **Self-improving toolchain**: Blogs about iterating on his own tools and workflows (e.g. improving the Claude skill itself). Meta, reflective, iterative.
 - **Problem → Solution structure**: Posts typically open with a real problem (often family-driven), walk through the build, include actual code/config, and close with the outcome.
 - **Short practical posts are fine**: Not every post is a deep dive — a quick terminal tip is worth publishing if it's useful.
 - **Design-before-build discipline**: Uses structured design interviews (via `/grill-me`) before touching config or code — resolves dependencies and surfaces hidden assumptions upfront rather than debugging them later.
+- **Blueprint-first projects**: Every new repo starts with a visual architecture blueprint (`blueprint.svg`) describing intent, components, and data flow — drawn before any code is written and embedded in the README.
 
 ### Blog posts
 - Open with context: what was the problem, why did it matter
@@ -43,6 +45,7 @@
 - Include real commands, config snippets, and error output
 - Acknowledge what's still broken or not ideal
 - Conversational sign-off, not a formal conclusion
+- Published as MDX in `src/content/posts/` of the www-andrewriley-info repo, served at `/p/<slug>`
 
 ### LinkedIn
 - Authentic, personal anecdotes tied to professional insight
@@ -54,5 +57,5 @@
 ## Skills That Use This Profile
 
 - `linkedin-post` — use name, role, tone, focus areas, and signature traits when drafting posts
-- `new-post-andrewriley-info` (in `~/dev/www-andrewriley-info`) — use writing voice, structure, and focus areas when writing blog posts
+- **Blog posts** — future posts on andrewriley.info will be drafted using this profile's voice and structure; the old Hugo `new-post` skill is retired and no replacement skill exists yet for the Next.js/MDX site
 - `keep-current` — reads PROFILE.md to infer communication style updates from session behaviour and project direction


### PR DESCRIPTION
## Summary
- Wire the shared `skills/common/PROFILE.md` into `~/.claude` so the profile is picked up by Claude Code, and repair any dangling symlinks during setup.
- Reprint the login banner/MOTD inside the auto-started tmux session so it's visible when tmux takes over the shell.

## Changes
- `setup.sh` — symlink wiring for PROFILE.md + dangling-symlink repair.
- `dev-workstation-build/install-dotfiles.sh` — reprint banner/MOTD inside tmux auto-start.
- `skills/common/PROFILE.md` — content updates.

## Test plan
- [ ] `./setup.sh --dry-run` previews cleanly
- [ ] Fresh shell starts tmux and shows the MOTD
- [ ] `~/.claude/PROFILE.md` resolves to the shared file

🤖 Generated with [Claude Code](https://claude.com/claude-code)