### PR TITLE
Sync managed RC blocks in place so edits propagate

### DIFF
--- a/dev-workstation-build/install-dotfiles.sh
+++ b/dev-workstation-build/install-dotfiles.sh
@@ -56,7 +56,10 @@ fi
 
 log "Shell RC files: ${RC_FILES[*]}"
 
-# Helper: append a block to a RC file if a guard string is not already present
+# Helper: append a block to a RC file if a guard string is not already present.
+# Add-once semantics — never rewrites an existing match. Use this for blocks a
+# user may have hand-rolled their own version of (e.g. the shell prompt), where
+# clobbering would be unwelcome.
 append_to_rc() {
   local rc_file="$1"
   local guard="$2" # grep pattern — if found, skip
@@ -72,6 +75,99 @@ append_to_rc() {
     ok "$label → $rc_file"
   fi
 }
+
+# Helper: keep a workstation-managed block in sync with desired content.
+# Blocks we own are wrapped in sentinel markers keyed by an id, so edits to the
+# block actually propagate on re-run (the original append_to_rc skips forever
+# once its guard matches, so changed content never lands on an existing machine):
+#   - markers present, content drifted → replaced in place      ("updated")
+#   - markers present, content identical → left alone            ("skip")
+#   - markers absent, legacy guard hit → legacy paragraph removed,
+#     managed block appended (one-time migration)                ("migrated")
+#   - neither present → managed block appended                   ("added")
+# Managed blocks have no internal blank lines and are blank-separated from their
+# neighbours, so a legacy (un-delimited) block is exactly the blank-line paragraph
+# containing its guard — which is what the migration removes.
+sync_block_to_rc() {
+  local rc_file="$1"
+  local key="$2"   # stable id for the sentinel markers
+  local guard="$3" # grep -F pattern identifying a pre-sentinel (legacy) block
+  local block="$4" # desired block body (without sentinels)
+  local label="$5"
+
+  local begin="# >>> workstation:${key} >>>"
+  local end="# <<< workstation:${key} <<<"
+  local desired
+  desired="$(printf '%s\n%s\n%s' "$begin" "$block" "$end")"
+
+  [ -e "$rc_file" ] || touch "$rc_file"
+
+  if grep -qF "$begin" "$rc_file" 2>/dev/null; then
+    # Managed block exists — replace only if it has drifted from desired.
+    local current
+    current="$(awk -v b="$begin" -v e="$end" '
+      $0==b {f=1} f {print} $0==e {f=0}' "$rc_file")"
+    if [ "$current" = "$desired" ]; then
+      skip "$label ($rc_file)"
+    elif $DRY_RUN; then
+      dryrun "Would update $label in $rc_file"
+    else
+      local tmp
+      tmp="$(mktemp)"
+      # $desired is multi-line — pass via the environment (awk -v mangles newlines).
+      DESIRED="$desired" awk -v b="$begin" -v e="$end" '
+        $0==b {print ENVIRON["DESIRED"]; inblk=1; next}
+        inblk && $0==e {inblk=0; next}
+        inblk {next}
+        {print}' "$rc_file" >"$tmp"
+      cat "$tmp" >"$rc_file"
+      rm -f "$tmp"
+      ok "$label updated → $rc_file"
+    fi
+    return
+  fi
+
+  # No managed block yet.
+  local legacy=false
+  grep -qF "$guard" "$rc_file" 2>/dev/null && legacy=true
+
+  if $DRY_RUN; then
+    if $legacy; then
+      dryrun "Would migrate $label to a managed block in $rc_file"
+    else
+      dryrun "Would append $label to $rc_file"
+    fi
+    return
+  fi
+
+  if $legacy; then
+    # Drop the blank-line paragraph containing the guard (plus its trailing blank
+    # separator), leaving every other line byte-identical, then append the managed
+    # block fresh.
+    local tmp
+    tmp="$(mktemp)"
+    awk -v g="$guard" '
+      function flush(  i) {
+        if (drop) { drop=0; n=0; dropped=1; return }
+        for (i=0;i<n;i++) print para[i]; n=0; dropped=0
+      }
+      /^[[:space:]]*$/ { flush(); if (dropped) { dropped=0; next } print; next }
+      { para[n++]=$0; if (index($0,g)) drop=1 }
+      END { flush() }' "$rc_file" >"$tmp"
+    cat "$tmp" >"$rc_file"
+    rm -f "$tmp"
+    printf '\n%s\n' "$desired" >>"$rc_file"
+    ok "$label migrated → $rc_file"
+  else
+    printf '\n%s\n' "$desired" >>"$rc_file"
+    ok "$label → $rc_file"
+  fi
+}
+
+# Test hook: source the script with WORKSTATION_LIB_ONLY=1 to load the helpers
+# (append_to_rc / sync_block_to_rc) without running the installer. No effect on a
+# normal run, where the variable is unset.
+[ -n "${WORKSTATION_LIB_ONLY:-}" ] && return 0 2>/dev/null || true
 
 # ── env.sh — secrets and API keys ────────────────────────────────────────────
 section "Environment Config (env.sh)"
@@ -98,7 +194,8 @@ fi
 
 # Wire env.sh sourcing into each shell RC
 for rc in "${RC_FILES[@]}"; do
-  append_to_rc "$rc" \
+  sync_block_to_rc "$rc" \
+    "env-sh" \
     "workstation/env.sh" \
     "# workstation — API keys and environment
 [ -f \"\$HOME/.config/workstation/env.sh\" ] && source \"\$HOME/.config/workstation/env.sh\"" \
@@ -108,7 +205,8 @@ done
 # ── PATH — ~/.local/bin ───────────────────────────────────────────────────────
 section "PATH — ~/.local/bin"
 for rc in "${RC_FILES[@]}"; do
-  append_to_rc "$rc" \
+  sync_block_to_rc "$rc" \
+    "path-local-bin" \
     '.local/bin' \
     '# ~/.local/bin on PATH (zoxide, yq, bat alias, uv tools)
 export PATH="$HOME/.local/bin:$PATH"' \
@@ -118,7 +216,8 @@ done
 # ── PATH — uv tools ───────────────────────────────────────────────────────────
 section "PATH — uv tools (~/.cargo/bin)"
 for rc in "${RC_FILES[@]}"; do
-  append_to_rc "$rc" \
+  sync_block_to_rc "$rc" \
+    "path-uv" \
     '.cargo/bin' \
     '# uv tools (aider, llm, etc.)
 export PATH="$HOME/.cargo/bin:$PATH"' \
@@ -129,7 +228,8 @@ done
 section "ai-env Alias"
 VENV_DIR="$HOME/ai-env"
 for rc in "${RC_FILES[@]}"; do
-  append_to_rc "$rc" \
+  sync_block_to_rc "$rc" \
+    "ai-env-alias" \
     "alias ai-env=" \
     "# Activate AI/ML Python environment
 alias ai-env='source $VENV_DIR/bin/activate'" \
@@ -140,7 +240,8 @@ done
 section "fnm Shell Integration"
 if command -v fnm &>/dev/null || [ -f "$HOME/.local/share/fnm/fnm" ]; then
   for rc in "${RC_FILES[@]}"; do
-    append_to_rc "$rc" \
+    sync_block_to_rc "$rc" \
+      "fnm" \
       'fnm env' \
       '# fnm — Fast Node Manager
 export PATH="$HOME/.local/share/fnm:$PATH"
@@ -157,13 +258,15 @@ if command -v zoxide &>/dev/null; then
   for rc in "${RC_FILES[@]}"; do
     # Detect shell type from filename
     if [[ "$rc" == *zshrc ]]; then
-      append_to_rc "$rc" \
+      sync_block_to_rc "$rc" \
+        "zoxide" \
         'zoxide init' \
         '# zoxide — smarter cd
 eval "$(zoxide init zsh)"' \
         "zoxide init (zsh)"
     else
-      append_to_rc "$rc" \
+      sync_block_to_rc "$rc" \
+        "zoxide" \
         'zoxide init' \
         '# zoxide — smarter cd
 eval "$(zoxide init bash)"' \
@@ -180,7 +283,8 @@ fi
 # Workstation profile on macOS, or the user's emulator theme on Linux.
 section "Terminal Colours"
 for rc in "${RC_FILES[@]}"; do
-  append_to_rc "$rc" \
+  sync_block_to_rc "$rc" \
+    "terminal-colours" \
     'BAT_THEME' \
     '# Terminal colours (workstation) — follow the terminal'"'"'s ANSI palette
 export CLICOLOR=1                  # BSD ls colour (macOS)
@@ -265,8 +369,7 @@ section "tmux"
 # (/etc/issue.net) and MOTD. Single-quoted so $f/$SHELL expand when tmux runs it,
 # not when the RC is sourced. Inside tmux $TMUX is set, so the exec'd login shell
 # won't recurse into this block.
-TMUX_AUTOSTART='# ── Auto-start tmux (workstation) ──
-if command -v tmux &>/dev/null && [[ $- == *i* ]] && [[ -z "${TMUX:-}" ]]; then
+TMUX_AUTOSTART='if command -v tmux &>/dev/null && [[ $- == *i* ]] && [[ -z "${TMUX:-}" ]]; then
   case "${TERM_PROGRAM:-}" in
     vscode | kiro | cursor | Cursor | Antigravity) ;;
     *)
@@ -275,7 +378,8 @@ if command -v tmux &>/dev/null && [[ $- == *i* ]] && [[ -z "${TMUX:-}" ]]; then
   esac
 fi'
 for rc in "${RC_FILES[@]}"; do
-  append_to_rc "$rc" \
+  sync_block_to_rc "$rc" \
+    "tmux-autostart" \
     'Auto-start tmux (workstation)' \
     "$TMUX_AUTOSTART" \
     "tmux auto-start"

--- a/dev-workstation-build/tests/test_dotfiles_sync.bats
+++ b/dev-workstation-build/tests/test_dotfiles_sync.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# Unit tests for sync_block_to_rc / append_to_rc in install-dotfiles.sh.
+# Focus: managed blocks update in place when their content drifts, legacy
+# (un-delimited) blocks migrate once, and unrelated RC content is preserved.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../install-dotfiles.sh"
+  # Load just the helpers — the hook returns before the installer body runs.
+  WORKSTATION_LIB_ONLY=1 source "$SCRIPT"
+  DRY_RUN=false
+  RC="$(mktemp)"
+}
+
+teardown() {
+  rm -f "$RC"
+}
+
+@test "sync adds a managed block with sentinel markers" {
+  sync_block_to_rc "$RC" "demo" "GUARD_STR" "export DEMO=1" "demo"
+  run grep -c '# >>> workstation:demo >>>' "$RC"
+  [ "$output" -eq 1 ]
+  grep -qF '# <<< workstation:demo <<<' "$RC"
+  grep -qF 'export DEMO=1' "$RC"
+}
+
+@test "sync is idempotent — identical content leaves the file byte-for-byte" {
+  sync_block_to_rc "$RC" "demo" "GUARD_STR" "export DEMO=1" "demo"
+  before="$(cat "$RC")"
+  sync_block_to_rc "$RC" "demo" "GUARD_STR" "export DEMO=1" "demo"
+  [ "$(cat "$RC")" = "$before" ]
+}
+
+@test "sync replaces a drifted managed block in place (no duplication)" {
+  sync_block_to_rc "$RC" "demo" "GUARD_STR" "export DEMO=1" "demo"
+  sync_block_to_rc "$RC" "demo" "GUARD_STR" "export DEMO=2" "demo"
+  # Exactly one block; new content present, old content gone.
+  run grep -c '# >>> workstation:demo >>>' "$RC"
+  [ "$output" -eq 1 ]
+  grep -qF 'export DEMO=2' "$RC"
+  ! grep -qF 'export DEMO=1' "$RC"
+}
+
+@test "sync migrates a legacy un-delimited block and preserves surrounding lines" {
+  cat >"$RC" <<'EOF'
+# user's own line above
+export USER_KEEP=yes
+
+# legacy demo block
+export DEMO=1
+
+# user's own line below
+export USER_KEEP2=yes
+EOF
+  sync_block_to_rc "$RC" "demo" "legacy demo block" "export DEMO=99" "demo"
+
+  # Managed block now present with new content; legacy paragraph gone.
+  grep -qF '# >>> workstation:demo >>>' "$RC"
+  grep -qF 'export DEMO=99' "$RC"
+  ! grep -qF '# legacy demo block' "$RC"
+  ! grep -qF 'export DEMO=1' "$RC"
+
+  # Unrelated user content untouched.
+  grep -qF 'export USER_KEEP=yes' "$RC"
+  grep -qF 'export USER_KEEP2=yes' "$RC"
+}
+
+@test "migration then re-run is idempotent" {
+  cat >"$RC" <<'EOF'
+# legacy demo block
+export DEMO=1
+EOF
+  sync_block_to_rc "$RC" "demo" "legacy demo block" "export DEMO=99" "demo"
+  after_migrate="$(cat "$RC")"
+  sync_block_to_rc "$RC" "demo" "legacy demo block" "export DEMO=99" "demo"
+  [ "$(cat "$RC")" = "$after_migrate" ]
+}
+
+@test "append_to_rc keeps add-once semantics (never clobbers an existing match)" {
+  printf '%s\n' "parse_git_branch() { echo custom; }" >"$RC"
+  before="$(cat "$RC")"
+  append_to_rc "$RC" "parse_git_branch" "# ours
+parse_git_branch() { echo ours; }" "shell prompt"
+  [ "$(cat "$RC")" = "$before" ]
+}


### PR DESCRIPTION
## Problem

`append_to_rc` skips forever once its guard string matches, so any change to a managed block's **content** never reaches a machine that already has the block. The MOTD reprint added in #13 was a casualty: committed, but the bare `exec tmux new-session` stayed on existing installs (including this workstation).

## Fix

Add `sync_block_to_rc` — workstation-owned blocks are wrapped in keyed sentinel markers (`# >>> workstation:<key> >>>` … `# <<< … <<<`):

| Situation | Before | After |
|---|---|---|
| Content drifted | skipped forever (the bug) | replaced in place |
| Content identical | skipped | skipped, byte-for-byte |
| Legacy un-delimited block | duplicate appended | migrated once; surrounding lines untouched |
| Absent | appended | appended (wrapped) |

All 8 managed blocks adopt it. The shell prompt deliberately stays on add-once `append_to_rc` so a hand-rolled `parse_git_branch` is never clobbered.

Notes:
- Multi-line replacement passes via `ENVIRON` — `awk -v` rejects embedded newlines.
- Redundant in-body tmux comment removed (the sentinel labels the block).

## Tests

New `tests/test_dotfiles_sync.bats` (6 cases: add / idempotent-skip / in-place replace / legacy migration / migrate-then-idempotent / add-once no-clobber), enabled by a `WORKSTATION_LIB_ONLY` source hook that loads the helpers without running the installer.

## Verification
- 18 bats tests pass (12 existing + 6 new); `shellcheck --severity=warning` and `shfmt -i 2 -ci` clean.
- Ran the installer on this workstation: the legacy tmux block migrated to managed form and now carries the MOTD reprint; a second run with the tidied comment reported `tmux auto-start updated` — confirming drift propagation end-to-end.
- Live `tmux new-session` test confirmed the banner reprints before the shell takes over. `zsh -n ~/.zshrc` parses clean; no duplicate blocks; prompt preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)